### PR TITLE
feat(mock): added return once

### DIFF
--- a/src/mock/Mock.ts
+++ b/src/mock/Mock.ts
@@ -43,13 +43,5 @@ export const mock = {
     date.toDateString = mock.return('19/01/1970');
     return date;
   },
-  returnOnce: (firstValueDefault: boolean, ...values: unknown[]): Mock => {
-    let mock = jest.fn();
-    if (values?.length > 0) {
-      values.forEach((value, index) => {
-        firstValueDefault && index === 0 ? (mock = jest.fn(() => value)) : (mock = mock.mockImplementationOnce(() => value));
-      });
-    }
-    return mock;
-  },
+  once: (...values: unknown[]): Mock => values.reduce((m: Mock, v: unknown) => m.mockImplementationOnce(() => v), jest.fn()),
 };

--- a/src/mock/Mock.ts
+++ b/src/mock/Mock.ts
@@ -43,4 +43,13 @@ export const mock = {
     date.toDateString = mock.return('19/01/1970');
     return date;
   },
+  returnOnce: (firstValueDefault: boolean, ...values: unknown[]): Mock => {
+    let mock = jest.fn();
+    if (values?.length > 0) {
+      values.forEach((value, index) => {
+        firstValueDefault && index === 0 ? (mock = jest.fn(() => value)) : (mock = mock.mockImplementationOnce(() => value));
+      });
+    }
+    return mock;
+  },
 };

--- a/test/mock/Mock.test.ts
+++ b/test/mock/Mock.test.ts
@@ -99,4 +99,27 @@ describe('mock', () => {
     expect(d.toString()).toBe(d2.toString());
     expect(d.toLocaleDateString()).toBe(d2.toLocaleDateString());
   });
+
+  test('return once works', () => {
+    const version2 = 'Version 43';
+    project.version = mock.returnOnce(false, version, version2);
+    expect(project.version(1)).toBe(version);
+    expect(project.version(2)).toBe(version2);
+    expect(project.version(3)).toBeUndefined();
+  });
+
+  test('return once default works', () => {
+    const version2 = 'Version 43';
+    project.version = mock.returnOnce(true, version, version2);
+    expect(project.version(1)).toBe(version2);
+    expect(project.version(2)).toBe(version);
+    expect(project.version(3)).toBe(version);
+  });
+
+  test('return once default no values works', () => {
+    project.version = mock.returnOnce(true);
+    expect(project.version(1)).toBeUndefined();
+    project.version = mock.returnOnce(false);
+    expect(project.version(1)).toBeUndefined();
+  });
 });

--- a/test/mock/Mock.test.ts
+++ b/test/mock/Mock.test.ts
@@ -100,26 +100,19 @@ describe('mock', () => {
     expect(d.toLocaleDateString()).toBe(d2.toLocaleDateString());
   });
 
+  test('return once default no values works', () => {
+    const m = mock.return(version);
+    m.mockImplementationOnce(() => 'version 3');
+
+    project.version = mock.once();
+    expect(project.version(1)).toBeUndefined();
+  });
+
   test('return once works', () => {
     const version2 = 'Version 43';
-    project.version = mock.returnOnce(false, version, version2);
-    expect(project.version(1)).toBe(version);
+    project.version = mock.once(version, version2);
+    expect(project.version(10)).toBe(version);
     expect(project.version(2)).toBe(version2);
     expect(project.version(3)).toBeUndefined();
-  });
-
-  test('return once default works', () => {
-    const version2 = 'Version 43';
-    project.version = mock.returnOnce(true, version, version2);
-    expect(project.version(1)).toBe(version2);
-    expect(project.version(2)).toBe(version);
-    expect(project.version(3)).toBe(version);
-  });
-
-  test('return once default no values works', () => {
-    project.version = mock.returnOnce(true);
-    expect(project.version(1)).toBeUndefined();
-    project.version = mock.returnOnce(false);
-    expect(project.version(1)).toBeUndefined();
   });
 });


### PR DESCRIPTION
Added the option to provide multiple implementations for the same mocked functions. So multiple calls to the same function can produce different results.